### PR TITLE
fix: send autocomplete choices back to Discord

### DIFF
--- a/packages/core/src/application-commands/command-registry.ts
+++ b/packages/core/src/application-commands/command-registry.ts
@@ -4,6 +4,7 @@ import {
   APIChatInputApplicationCommandInteraction,
   APIContextMenuInteraction,
   ApplicationCommandType,
+  InteractionResponseType,
   RESTPostAPIApplicationCommandsJSONBody,
   Routes,
   Snowflake
@@ -243,7 +244,25 @@ export class CommandRegistry {
 
     this.conductr.emit('commandAutocompleteInteraction', interaction, command);
 
-    handlers.autocomplete(interaction, new AutocompleteInteraction(interaction));
+    const choices = await handlers.autocomplete(interaction, new AutocompleteInteraction(interaction));
+
+    // A handler may respond to the interaction itself by returning undefined.
+    if (choices === undefined) {
+      return;
+    }
+
+    if (!this.rest) {
+      throw new Error('Cannot respond to an autocomplete interaction without a rest client.');
+    }
+
+    // Send the choices back to Discord. Without this the suggestions never reach the client.
+    await this.rest.post(Routes.interactionCallback(interaction.id, interaction.token), {
+      body: {
+        type: InteractionResponseType.ApplicationCommandAutocompleteResult,
+        data: { choices }
+      },
+      auth: false
+    });
   }
 
   async processContextMenu(interaction: APIContextMenuInteraction): Promise<void> {

--- a/packages/core/test/autocomplete.spec.ts
+++ b/packages/core/test/autocomplete.spec.ts
@@ -1,0 +1,97 @@
+import {
+  APIApplicationCommandAutocompleteInteraction,
+  APIApplicationCommandOptionChoice,
+  ApplicationCommandOptionType,
+  ApplicationCommandType,
+  InteractionResponseType,
+  InteractionType,
+  Routes
+} from '@discordjs/core';
+import type { REST } from '@discordjs/rest';
+import { CommandRegistry } from '../src/application-commands/command-registry';
+import { SlashCommandCreator } from '../src/application-commands/slash-commands';
+import type { Conductr } from '../src/conductr';
+
+function buildInteraction(focusedValue = 'fo'): APIApplicationCommandAutocompleteInteraction {
+  return {
+    id: '123',
+    token: 'interaction-token',
+    type: InteractionType.ApplicationCommandAutocomplete,
+    data: {
+      id: '456',
+      name: 'search',
+      type: ApplicationCommandType.ChatInput,
+      options: [
+        {
+          name: 'query',
+          type: ApplicationCommandOptionType.String,
+          value: focusedValue,
+          focused: true
+        }
+      ]
+    }
+  } as unknown as APIApplicationCommandAutocompleteInteraction;
+}
+
+function buildRegistry(autocompleteResult: APIApplicationCommandOptionChoice[] | undefined) {
+  const conductr = { emit: jest.fn() } as unknown as Conductr;
+  const rest = { post: jest.fn().mockResolvedValue(undefined) } as unknown as REST;
+
+  const registry = new CommandRegistry(conductr, rest);
+
+  const command = new SlashCommandCreator()
+    .setName('search')
+    .setDescription('Search for things')
+    .addStringOption(option => option.setName('query').setDescription('The query').setAutocomplete(true))
+    .handleInteraction(() => {})
+    .handleAutocompleteInteraction(() => autocompleteResult)
+    .create();
+
+  registry.registerCommand(command);
+
+  return { registry, rest, conductr };
+}
+
+describe('CommandRegistry#processCommandAutocomplete', () => {
+  it('sends the returned choices back to Discord (regression for dropped autocomplete results)', async () => {
+    const choices: APIApplicationCommandOptionChoice[] = [
+      { name: 'Foo', value: 'foo' },
+      { name: 'Food', value: 'food' }
+    ];
+    const { registry, rest } = buildRegistry(choices);
+
+    await registry.processCommandAutocomplete(buildInteraction());
+
+    expect(rest.post).toHaveBeenCalledTimes(1);
+    expect(rest.post).toHaveBeenCalledWith(Routes.interactionCallback('123', 'interaction-token'), {
+      body: {
+        type: InteractionResponseType.ApplicationCommandAutocompleteResult,
+        data: { choices }
+      },
+      auth: false
+    });
+  });
+
+  it('sends an empty choices list when the handler returns no results', async () => {
+    const { registry, rest } = buildRegistry([]);
+
+    await registry.processCommandAutocomplete(buildInteraction());
+
+    expect(rest.post).toHaveBeenCalledTimes(1);
+    expect(rest.post).toHaveBeenCalledWith(Routes.interactionCallback('123', 'interaction-token'), {
+      body: {
+        type: InteractionResponseType.ApplicationCommandAutocompleteResult,
+        data: { choices: [] }
+      },
+      auth: false
+    });
+  });
+
+  it('does not respond when the handler opts out by returning undefined', async () => {
+    const { registry, rest } = buildRegistry(undefined);
+
+    await registry.processCommandAutocomplete(buildInteraction());
+
+    expect(rest.post).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Problem

Autocomplete/search options never showed suggestions in the Discord client. `CommandRegistry.processCommandAutocomplete()` invoked the user's autocomplete handler but **discarded its return value** — the computed choices were never sent to Discord's interaction-callback endpoint.

The handler type (`SlashCommandAutocompleteHandler`) returns `APIApplicationCommandOptionChoice[]`, clearly intending those choices to be returned to Discord, but nothing in the package responded to autocomplete interactions (no `InteractionResponseType` / `interactionCallback` usage existed anywhere).

## Fix

`processCommandAutocomplete` now awaits the handler and POSTs the returned choices via `Routes.interactionCallback` with `InteractionResponseType.ApplicationCommandAutocompleteResult`.

- Returning `undefined` opts out of the auto-response (handler may respond itself).
- Returning `[]` sends an explicit empty result.
- `auth: false` since interaction callbacks authenticate via the interaction token in the URL.

## Tests

Adds `packages/core/test/autocomplete.spec.ts` covering:
- returned choices are POSTed back to Discord (the regression),
- empty results send an empty choices list,
- `undefined` opts out of responding.

Verified the tests fail against the pre-fix behavior and pass with the fix.